### PR TITLE
fix issue 14

### DIFF
--- a/lib/thor-scmversion/p4_version.rb
+++ b/lib/thor-scmversion/p4_version.rb
@@ -106,9 +106,9 @@ module ThorSCMVersion
     
     def tag
       if ThorSCMVersion.windows?
-        `type #{File.expand_path(get_p4_label_file).gsub(File::Separator, File::ALT_SEPARATOR)} | p4 label -i`
+        `type "#{File.expand_path(get_p4_label_file).gsub(File::Separator, File::ALT_SEPARATOR)}" | p4 label -i`
       else
-        `cat #{File.expand_path(get_p4_label_file)} | p4 label -i`
+        `cat "#{File.expand_path(get_p4_label_file)}" | p4 label -i`
       end
     end
 


### PR DESCRIPTION
- Move the `windows?` method up to the module level so it can be leveraged in more places.
- Use `p4 where` instead of `p4 dirs` to get depot information.
- Quote the p4 commands that use a path because Jenkins jobs use spaces in their paths.
