### PR TITLE
P4 scm is assumed if .git is not a directory

### DIFF
--- a/features/bump.feature
+++ b/features/bump.feature
@@ -51,3 +51,10 @@ Feature: Bump
     When I run `bundle exec thor version:bump patch` from the temp directory
     Then the version should be '1.0.11'
     And the git server version should be '1.0.11'
+
+   Scenario: Bumping a version in a git submodule
+     Given I have a git project of version '1.2.3'
+     And .git is a file pointing to the .git folder in a parent module
+     When I run `bundle exec thor version:bump patch ` from the temp directory
+     Then the version should be '1.2.4'
+     And the git server version should be '1.2.4'

--- a/features/step_definitions/bump_steps.rb
+++ b/features/step_definitions/bump_steps.rb
@@ -126,3 +126,11 @@ Given(/^there is a tag '(.*)'$/) do |version|
     `git tag #{version}`
   end
 end
+
+Given(/^.git is a file pointing to the .git folder in a parent module$/) do
+  project_git_path = File.join(project_dir, '.git')
+  git_folder_path  = File.join(parent_module_dir, '.git')
+  File.directory?( project_git_path ).should be_true
+  File.rename project_git_path, git_folder_path
+  `echo "gitdir: #{ git_folder_path }" > "#{ project_git_path }"`
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,6 +19,10 @@ def origin_dir
   @origindir ||= Dir.mktmpdir
 end
 
+def parent_module_dir
+  @parentmoduledir ||= Dir.mktmpdir
+end
+
 def fixtures_dir
   File.join(File.dirname(__FILE__), "..", "fixtures")
 end

--- a/lib/thor-scmversion/scm_version.rb
+++ b/lib/thor-scmversion/scm_version.rb
@@ -5,7 +5,7 @@ module ThorSCMVersion
     #
     # @return [#kind_of? ScmVersion]
     def versioner
-      if(File.directory?(".git"))
+      if(File.exist?  (".git"))
         return GitVersion
       else
         return P4Version


### PR DESCRIPTION
If, for example, my project is a submodule, then .git will be a file with content: "gitdir: ../.git/modules/mymodule" 

This causes "thor scmversion:current" to fail while attempting nonexistent p4 commands.
