### PR TITLE
Issue #32 - Use mixlib-shellout for a better time shelling out

### DIFF
--- a/lib/thor-scmversion/shell_utils.rb
+++ b/lib/thor-scmversion/shell_utils.rb
@@ -1,35 +1,26 @@
+require 'mixlib/shellout'
+
 module ThorSCMVersion
   class ShellUtils
     class << self
       def secure_password
         password = String.new
-        
+
         while password.length < 20
           password << ::OpenSSL::Random.random_bytes(1).gsub(/\W/, '')
         end
         password
       end
-      
+
       def sh(cmd, dir = '.', &block)
         out, code = sh_with_excode(cmd, dir, &block)
         code == 0 ? out : raise(out.empty? ? "Running `#{cmd}` failed. Run this command directly for more detailed output." : out)
       end
-      
-      def sh_with_excode(cmd, dir = '.', &block)
-        cmd << " 2>&1"
-        output = ""
-        status = nil
-        Dir.chdir(dir) {
-          stdin, stdout, stderr, wait_thr = Open3::popen3(cmd)
-          
-          status = wait_thr.value
-          output = stdout.readlines.join
 
-          if status.to_i == 0
-            block.call(output) if block
-          end
-        }
-        [ output, status ]
+      def sh_with_excode(cmd, dir = '.', &block)
+        command = Mixlib::ShellOut.new(cmd << " 2>&1", :cwd => dir)
+        command.run_command
+        [command.stdout, command.exitstatus]
       end
     end
   end

--- a/thor-scmversion.gemspec
+++ b/thor-scmversion.gemspec
@@ -15,7 +15,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ThorSCMVersion::VERSION
 
-  gem.add_dependency             'thor'
+  gem.add_dependency 'thor'
+  gem.add_dependency 'mixlib-shellout'
+
   gem.add_development_dependency 'webmock'
   gem.add_development_dependency 'geminabox'
   gem.add_development_dependency 'spork'


### PR DESCRIPTION
Mixlib is able to handle cases where git prompts for creds.
