### PR TITLE
Yoshiwaan file and tag split options

### DIFF
--- a/lib/thor-scmversion.rb
+++ b/lib/thor-scmversion.rb
@@ -13,7 +13,7 @@ module ThorSCMVersion
     namespace "version"
 
     desc "bump TYPE [PRERELEASE_TYPE]", "Bump version number (type is major, minor, patch, prerelease or auto)"\
-    "in VERSION file and create tag."
+    " in VERSION file and create tag."
     method_option :default, type: :string, aliases: "-d"
     def bump(type, prerelease_type = nil)
       current_version.bump! type, options.merge(prerelease_type: prerelease_type)
@@ -35,7 +35,7 @@ module ThorSCMVersion
     end
 
     desc "bumpfile TYPE [PRERELEASE_TYPE]", "Bump version number in VERSION file only"\
-    "(type is major, minor, patch, prerelease or auto). Does not create tag."
+    " (type is major, minor, patch, prerelease or auto). Does not create tag."
     method_option :default, type: :string, aliases: "-d" # TODO
     def bumpfile(type, prerelease_type = nil)
       current_version.bump! type, options.merge(prerelease_type: prerelease_type)

--- a/lib/thor-scmversion/scm_version.rb
+++ b/lib/thor-scmversion/scm_version.rb
@@ -29,6 +29,17 @@ module ThorSCMVersion
     # Default file to write the current version to
     VERSION_FILENAME = 'VERSION'
     class << self
+
+      # Retrieve version from file named VERSION at path
+      #
+      # @param [String] path Path to repository (containing VERSION file)
+      # @return [Array<ScmVersion>]
+      def from_file(path = '.')
+        filepath = File.join(path, 'VERSION')
+        fileversion = File.open(filepath).read
+        from_tag(fileversion)
+      end
+
       # Retrieve all versions from the repository contained at path
       #
       # @param [String] path Path to the repository


### PR DESCRIPTION
Added new methods to better accommodate users working with Chef.

 * version:bumpfile - Bumps the version in the VERSION file using the same logic as bump, but does not create a tag
 * version:tag - Creates a tag based on the version written in the VERSION file

The problem for Chef users currently is that the metadata.rb file needs to reference a semantic version as well, and as such users can use the VERSION file. However when it comes to pushing this into github the version file is either A) ignored, meaning the cookbook doesn't work or B) the version file is one below the git tag, as the tag is created before the VERSION file is incremented and there is no chance to add the VERSION file to the commit.

Using the above methods to the workflow for a Chef user would be something like
 * Build server checks out cookbook and runs tests
 * If tests pass then build server runs version:bumpfile
 * Commit updated VERSION file
 * Create tag based on VERSION file, including VERSION file in tag

Note this was tested with git, but untested in p4.