### PR TITLE
Speed up tags lookup

### DIFF
--- a/lib/thor-scmversion/git_version.rb
+++ b/lib/thor-scmversion/git_version.rb
@@ -3,22 +3,20 @@ require 'open3'
 module ThorSCMVersion
   class GitVersion < ScmVersion
     class << self
-      def all_from_path(path)
+      def tags_from_path(path)
         Dir.chdir(path) do
           tags = Open3.popen3("git tag") { |stdin, stdout, stderr| stdout.read }.split(/\n/)
           tags.select { |tag| tag.match(ScmVersion::VERSION_FORMAT) }
             .collect { |tag| from_tag(tag) }
-            .select { |tag| contained_in_current_branch?(tag) }.sort.reverse
         end
       end
 
+      def all_from_path(path)
+        tags_from_path(path).select { |tag| contained_in_current_branch?(tag) }.sort.reverse
+      end
+
       def latest_from_path(path)
-        Dir.chdir(path) do
-          tags = Open3.popen3("git tag") { |stdin, stdout, stderr| stdout.read }.split(/\n/)
-          tags.select { |tag| tag.match(ScmVersion::VERSION_FORMAT) }
-            .collect { |tag| from_tag(tag) }.sort.reverse
-            .find { |tag| contained_in_current_branch?(tag) }
-        end
+        tags_from_path(path).sort.reverse.find { |tag| contained_in_current_branch?(tag) }
       end
 
       def contained_in_current_branch?(tag)

--- a/lib/thor-scmversion/git_version.rb
+++ b/lib/thor-scmversion/git_version.rb
@@ -2,13 +2,22 @@ require 'open3'
 
 module ThorSCMVersion
   class GitVersion < ScmVersion
-    class << self          
+    class << self
       def all_from_path(path)
         Dir.chdir(path) do
           tags = Open3.popen3("git tag") { |stdin, stdout, stderr| stdout.read }.split(/\n/)
           tags.select { |tag| tag.match(ScmVersion::VERSION_FORMAT) }
             .collect { |tag| from_tag(tag) }
             .select { |tag| contained_in_current_branch?(tag) }.sort.reverse
+        end
+      end
+
+      def latest_from_path(path)
+        Dir.chdir(path) do
+          tags = Open3.popen3("git tag") { |stdin, stdout, stderr| stdout.read }.split(/\n/)
+          tags.select { |tag| tag.match(ScmVersion::VERSION_FORMAT) }
+            .collect { |tag| from_tag(tag) }.sort.reverse
+            .find { |tag| contained_in_current_branch?(tag) }
         end
       end
 
@@ -20,7 +29,7 @@ module ThorSCMVersion
         ShellUtils.sh("git fetch --all")
       end
     end
-        
+
     def tag
       begin
         ShellUtils.sh "git tag -a -m \"Version #{self}\" #{self}"

--- a/lib/thor-scmversion/p4_version.rb
+++ b/lib/thor-scmversion/p4_version.rb
@@ -9,12 +9,12 @@ module ThorSCMVersion
     def initialize(config_option)
       @config_option = config_option
     end
-    
+
     def message
       "#{@config_option} is not set in your environment."
     end
   end
-  
+
   module Perforce
     class << self
       def check_environment
@@ -22,11 +22,11 @@ module ThorSCMVersion
           raise MissingP4ConfigException.new(config) if ENV[config].nil? or ENV[config].empty?
         }
       end
-      
+
       def set
         ShellUtils.sh "p4 set"
       end
-      
+
       def parse_and_set_p4_set
         p4_set = set
         parsed_p4_config = p4_set.split("\n").inject({}) do |p4_config, line|
@@ -35,10 +35,10 @@ module ThorSCMVersion
           p4_config[key] = value
           p4_config
         end
-        
+
         parsed_p4_config.each {|key,value| ENV[key] = value}
       end
-      
+
       def connection
         parse_and_set_p4_set
         check_environment
@@ -63,11 +63,15 @@ module ThorSCMVersion
 
           if current_versions.empty?
             first_instance = new(0, 0, 0)
-          end 
+          end
 
           current_versions << first_instance if current_versions.empty?
           current_versions
         end
+      end
+
+      def latest_from_path(path)
+        all_from_path(path).first
       end
 
       def depot_path(path)
@@ -85,7 +89,7 @@ module ThorSCMVersion
       end
 
       def get_thor_scmversion_labels(labels, p4_module_name)
-        labels.select{|label| label.split(" ")[1].gsub("#{p4_module_name}-", "").match(ScmVersion::VERSION_FORMAT)}        
+        labels.select{|label| label.split(" ")[1].gsub("#{p4_module_name}-", "").match(ScmVersion::VERSION_FORMAT)}
       end
     end
 
@@ -94,7 +98,7 @@ module ThorSCMVersion
       self.p4_module_name = self.class.module_name('.')
       super
     end
-    
+
     attr_accessor :version_file_path
     attr_accessor :p4_depot_path
     attr_accessor :p4_module_name
@@ -103,7 +107,7 @@ module ThorSCMVersion
       # noop
       # p4 always has labels available, you just have to ask the server for them.
     end
-    
+
     def tag
       if ThorSCMVersion.windows?
         `type "#{File.expand_path(get_p4_label_file).gsub(File::Separator, File::ALT_SEPARATOR)}" | p4 label -i`
@@ -120,7 +124,7 @@ module ThorSCMVersion
     private
 
       def get_label_name
-        "#{p4_module_name}-#{self}"  
+        "#{p4_module_name}-#{self}"
       end
 
       def get_p4_label_template

--- a/lib/thor-scmversion/scm_version.rb
+++ b/lib/thor-scmversion/scm_version.rb
@@ -16,7 +16,7 @@ module ThorSCMVersion
   # author Josiah Kiehl <josiah@skirmisher.net>
   class ScmVersion
     include Comparable
-    
+
     # Tags not matching this format will not show up in the tags list
     #
     # Examples:
@@ -35,7 +35,7 @@ module ThorSCMVersion
       # @return [Array<ScmVersion>]
       def from_path(path = '.')
         retrieve_tags
-        all_from_path(path).first || new(0,0,1)
+        latest_from_path(path) || new(0,0,1)
       end
 
       # Create an ScmVersion object from a tag
@@ -69,7 +69,7 @@ module ThorSCMVersion
     end
 
     # Bumps the version in place
-    # 
+    #
     # @param [Symbol] type Type of bump to be performed
     # @param [String] prerelease_type Type of prerelease to bump to when doing a :prerelease bump
     # @return [ScmVersion]
@@ -78,7 +78,7 @@ module ThorSCMVersion
       when :auto
         self.auto_bump(options)
       when :major
-        self.major += 1        
+        self.major += 1
       when :minor
         self.minor += 1
       when :patch
@@ -114,12 +114,12 @@ module ThorSCMVersion
           self.minor = 0
         }],
        [:minor, Proc.new {
-          self.patch = 0 
+          self.patch = 0
         }],
        [:patch, Proc.new {
           self.prerelease = nil
         }],
-       [:prerelease, Proc.new { 
+       [:prerelease, Proc.new {
           self.build = 1
         }]].each do |matcher, reset_proc|
         next unless matched or type.to_sym == matcher
@@ -134,14 +134,14 @@ module ThorSCMVersion
     # @param [Array<String>] files List of files to write
     def write_version(files = [ScmVersion::VERSION_FILENAME])
       files.each do |ver_file|
-        File.open(ver_file, 'w+') do |f| 
+        File.open(ver_file, 'w+') do |f|
           f.write self.to_s
         end
       end
       self
     end
 
-    # Create the tag in the SCM corresponding to the version contained in self. 
+    # Create the tag in the SCM corresponding to the version contained in self.
     # Abstract method. Must be implemented by subclasses.
     def tag
       raise NotImplementedError
@@ -164,7 +164,7 @@ module ThorSCMVersion
     def <=>(other)
       return unless other.is_a?(self.class)
       return 0 if self.version == other.version
-      
+
       [:major, :minor, :patch, :prerelease, :build].each do |segment|
         next      if self.send(segment) == other.send(segment)
         return  1 if self.send(segment) > other.send(segment)

--- a/spec/lib/thor-scmversion/git_version_spec.rb
+++ b/spec/lib/thor-scmversion/git_version_spec.rb
@@ -9,5 +9,24 @@ module ThorSCMVersion
 OUT
       expect(GitVersion.contained_in_current_branch?('0.0.1')).to be_true
     end
+
+    describe '::latest_from_path' do
+      it 'returns the latest tag' do
+        Open3.stub(:popen3).and_yield(nil, StringIO.new("0.0.1\n0.0.2"), nil)
+        ShellUtils.stub(:sh).and_return(<<OUT)
+* constrain_bump_to_branch
+  master
+OUT
+        GitVersion.stub(:contained_in_current_branch?).and_return(true)
+
+        expect(GitVersion.latest_from_path('.').to_s).to eq('0.0.2')
+      end
+
+      it 'only shells out once if multiple tags are included in the branch' do
+        Open3.stub(:popen3).and_yield(nil, StringIO.new("0.0.1\n0.0.2"), nil)
+        expect(ShellUtils).to receive(:sh).once.and_return('*')
+        GitVersion.latest_from_path('.')
+      end
+    end
   end
 end


### PR DESCRIPTION
For repositories with a large number of tags, the call to `all_from_path` can take a significant amount of time, because it gets all tags, then checks to see if all of them are `contained_in_current_branch?`.

Here's an example of a repository with 234 tags that all match the version format regex. Before these changes, the checks to `contained_in_current_branch?` took ~10 seconds:

![screen shot 2016-03-10 at 11 00 22 am](https://cloud.githubusercontent.com/assets/4718399/13675406/6edcb2ca-e6af-11e5-92c1-08e6e0925c42.png)

After these changes, the lookup took 0.05 seconds, because it only had to call `contained_in_current_branch?` once:

![screen shot 2016-03-10 at 11 00 40 am](https://cloud.githubusercontent.com/assets/4718399/13675455/b08f2e00-e6af-11e5-979f-181937ccefb9.png)

I don't have enough knowledge of p4 to implement a similar change in `P4Version`, so I just have it calling `all_from_path(path).first` for now.
